### PR TITLE
fix: put jsdom's localStorage back on Node 26

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
     // environment at all. Component tests opt into jsdom per file with a
     // // @vitest-environment jsdom pragma.
     environment: 'node',
+    // Repairs localStorage for the files that opt into jsdom. See the
+    // comment in vitest.setup.ts for what Node broke and why.
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     coverage: {
       provider: 'v8',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,29 @@
+/*
+ * Put jsdom's localStorage back.
+ *
+ * Node 26 defines `localStorage` on globalThis as a getter that returns
+ * undefined unless the process was started with --localstorage-file. Vitest's
+ * jsdom environment refuses to install any global the runtime has already
+ * defined, and localStorage is on neither its built-in key list nor the
+ * per-environment additions, so jsdom's own Storage never lands and every test
+ * that reads or writes it fails with "Cannot read properties of undefined". A
+ * `// @vitest-environment jsdom` pragma cannot help, because the environment is
+ * not what is missing: document and the rest are all there.
+ *
+ * Vitest keeps the JSDOM instance on `globalThis.jsdom` and deletes it again at
+ * teardown, so reading through it is what keeps this honest. A getter rather
+ * than a fixed value because a worker runs many files: a value captured from
+ * one jsdom file would still be sitting here, backed by a closed window, when
+ * the next file runs. Resolving on every read gives each jsdom file its own
+ * Storage, and gives the node environment undefined, which is what it has
+ * today.
+ *
+ * sessionStorage is left alone: Node's built-in one works without a flag, so it
+ * is the wrong object rather than a missing one, and no test depends on it.
+ */
+Object.defineProperty(globalThis, 'localStorage', {
+  get: () =>
+    (globalThis as { jsdom?: { window: { localStorage: unknown } } }).jsdom?.window
+      .localStorage,
+  configurable: true,
+});


### PR DESCRIPTION
Closes #19.

On Node 26 the suite fails 48 tests on a clean checkout, in `src/backup.test.ts`,
`src/savedDesigns.test.ts` and `src/content/preferences.test.ts`, all of which already opt into
jsdom. Node 26 defines `localStorage` on `globalThis` as a getter returning `undefined` unless
the process was started with `--localstorage-file`, and vitest declines to install any jsdom
global the runtime already defines, so jsdom's `Storage` never lands. `.husky/pre-push` runs the
same gate, so it also blocks every push from such a machine.

This reads the Storage back off the JSDOM instance vitest parks on `globalThis.jsdom`.

Before and after, same tree, `bun run test`:

| runtime | before | after |
| --- | --- | --- |
| Node 22.23.2 | 855/855 pass | 855/855 pass |
| Node 24.20.0 | 855/855 pass | 855/855 pass |
| Node 26.7.0 | 48 failed, 807 passed | 855/855 pass |

A getter rather than a captured value, because a worker runs many files in turn and a value
taken from one jsdom file would still be present for the next one, backed by a closed window.
`src/clipboard.test.ts` runs under the node environment while importing a module that reads
`localStorage`, so that would leak into it. Resolving per read gives each jsdom file its own
Storage and gives the node environment `undefined`, which is what it has today. Nothing in the
repo assigns to `localStorage`, so a getter with no setter is safe.

A structural type rather than `Window`, because `tsconfig.node.json` sets `lib: ["ES2023"]` with
no DOM lib and this file is not covered by either project anyway.

## Scope

Two files, as asked on the issue: `vitest.setup.ts` and the `setupFiles` line in
`vitest.config.ts`.

No `.node-version` here. Having gone and looked, it would not do the job you wanted from it in
this repo. CI installs the runtime with `oven-sh/setup-bun` and has no `setup-node` step, so
nothing in the workflow reads it, and Vercel resolves the Node version from Project Settings or
`engines.node` and does not consult `.node-version` at all. It would document intent to local
version managers only, and to no machine that gates anything.

The bigger reason is that after this change there is no longer a version to pin against: 22, 24
and 26 all report 855/855. A pin would encode a constraint that this patch removes.

Two things worth knowing if you do want to pin separately. Vercel currently offers 20.x, 22.x
and 24.x with 24.x as the default, so Node 26 is not available there in any case. And on Vercel
`engines.node` is not only an install warning, it overrides the Node version in Project
Settings, which is a second reason to keep it out of `package.json`.

No behaviour change to the app, so no screenshot. `typecheck`, `lint`, `format:check` and
`build` all pass, and `lint` reports the same 26 warnings as `main`.

Not verified: Node 25, so the boundary is pinned only to "24 fine, 26 broken".
