### PR TITLE
feat: say what a design is made of, not just how big it is

### DIFF
--- a/src/components/Canvas.css
+++ b/src/components/Canvas.css
@@ -1125,6 +1125,25 @@
   text-transform: none;
 }
 
+/* The category breakdown drops out well before the phone breakpoint, because
+   it is by far the longest thing in this row and it runs INTO the zoom
+   cluster rather than off the screen.
+
+   Measured in the browser rather than estimated. The widest breakdown any
+   example produces is Discord's "6 traffic, 9 compute, 1 data, 2 stores,
+   2 messaging, 1 control", which takes the ledger to 737px, ending at x=1029.
+   The zoom cluster sits 181px in from the right edge, so the two meet at a
+   viewport of 1210px. 1240 leaves a little room rather than sitting on the
+   number. Above it the row is comfortable at every width up to 2560.
+
+   The totals stay at every size. They are what a reader glances at; the
+   breakdown is the elaboration, so it is the right thing to lose first. */
+@media (max-width: 1240px) {
+  .cv-ledger-groups {
+    display: none;
+  }
+}
+
 /* The contextual hint line: top centre, in the slot the armed-link
    instruction also uses, so the two never stack. Quiet text straight on the
    canvas, no border, no surface, no motion — guidance, not chrome.

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -28,10 +28,12 @@ import type {
 import {
   ICON_BOX,
   ICON_STROKE,
+  KIND_GROUPS,
   KIND_ICON,
   KIND_NAME,
   NODE_DND_MIME,
   cellStrip,
+  groupOfKind,
   stackBadge,
   stackLayers,
 } from './nodeVisuals';
@@ -5361,6 +5363,32 @@ export default function Canvas({
     return m;
   }, [topology.nodes]);
 
+  /**
+   * What the design is made of, by category: "4 traffic, 7 compute, 3 data".
+   *
+   * The total says how big a diagram is; the breakdown says what kind of
+   * system it is, which is what a reader is trying to work out about a
+   * reconstruction they did not build themselves.
+   *
+   * Groups print in taxonomy order, not by size, so the line matches the
+   * order of the rail and does not reshuffle itself every time a node is
+   * dropped. Empty groups are left out: eleven of the twenty-three examples
+   * touch only three of the six, and "0 messaging" on a three-box chain is
+   * noise. The group's `id` is the name printed, because "specialised
+   * stores" is too long for a corner that also has to hold two totals and a
+   * clock.
+   */
+  const nodeGroupSummary = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const n of topology.nodes) {
+      const group = groupOfKind(n.kind);
+      if (group) counts.set(group.id, (counts.get(group.id) ?? 0) + 1);
+    }
+    return KIND_GROUPS.filter((g) => counts.has(g.id))
+      .map((g) => `${counts.get(g.id)} ${g.id}`)
+      .join(', ');
+  }, [topology.nodes]);
+
   const detail: 0 | 1 | 2 = view.k >= DETAIL_ZOOM ? 2 : view.k >= MINIMAL_ZOOM ? 1 : 0;
   const showEdgeLabels = view.k >= 1;
 
@@ -6001,6 +6029,13 @@ export default function Canvas({
             {topology.nodes.length}{' '}
             {topology.nodes.length === 1 ? 'component' : 'components'}
           </span>
+          {/* The breakdown elaborates the total above it, so it sits next to
+              it rather than at the end. Commas inside one span, not the flex
+              gap: the gap separates FACTS, and split across spans "4 traffic
+              7 compute" would read as two more of them. A comma inherits
+              --text-faint from the text around it, so it carries none of the
+              contrast problem the old "·" separator did. */}
+          <span className="cv-ledger-groups">{nodeGroupSummary}</span>
           <span>
             {topology.edges.length}{' '}
             {topology.edges.length === 1 ? 'connection' : 'connections'}

--- a/src/components/Palette.tsx
+++ b/src/components/Palette.tsx
@@ -4,11 +4,13 @@ import type { NodeKind } from '../sim/types';
 import {
   ICON_BOX,
   ICON_STROKE,
+  KIND_GROUPS,
   KIND_ICON,
   KIND_NAME,
   KIND_TERM,
   NODE_DND_MIME,
 } from './nodeVisuals';
+import type { KindGroup } from './nodeVisuals';
 import { Term } from './Tooltip';
 import { usePreference } from '../content/preferences';
 import { useVendor } from '../content/vendors/useVendor';
@@ -24,17 +26,9 @@ import './Palette.css';
  * flat that is a 1100px column: a wall of text that must be scrolled to
  * be read, which means the student cannot see what the app offers.
  *
- * The fix is GROUPING, not shrinking. Four groups of 3-4 kinds each are
- * scannable at a glance because each group answers one question:
- *
- *   Traffic    where load comes from and how it is spread
- *   Compute    the things that do work and can saturate
- *   Data       the things that store it, and the two ways to scale that
- *   Control    the things that protect the system by refusing work
- *
- * A student looking for "how do I stop this melting" goes straight to
- * Control without reading the other eleven names. That is the whole
- * point of the taxonomy — it is a lookup index, not decoration.
+ * The fix is GROUPING, not shrinking. The groups themselves are
+ * KIND_GROUPS in nodeVisuals.ts, shared with the canvas ledger; what the
+ * rail adds is the rendering.
  *
  * Sections collapse, and the open/closed state is local UI state that
  * the shell does not need to know about. Components stay open by
@@ -42,61 +36,6 @@ import './Palette.css';
  * that is how a student starts. Keys is closed — it is a reference, not
  * a task.
  * ------------------------------------------------------------------ */
-
-interface KindGroup {
-  id: string;
-  title: string;
-  kinds: NodeKind[];
-}
-
-const KIND_GROUPS: KindGroup[] = [
-  { id: 'traffic', title: 'Traffic', kinds: ['client', 'lb', 'cdn', 'edgecompute'] },
-  {
-    id: 'compute',
-    title: 'Compute',
-    kinds: ['service', 'worker', 'queue', 'retryqueue', 'transcoder'],
-  },
-  {
-    id: 'data',
-    title: 'Data',
-    kinds: ['db', 'cache', 'writebehind', 'replica', 'shard'],
-  },
-  {
-    // The polyglot-persistence shelf: each of these exists because putting
-    // its workload in the main database is the mistake it teaches against.
-    id: 'stores',
-    title: 'Specialised stores',
-    kinds: [
-      'objectstore',
-      'searchindex',
-      'timeseriesdb',
-      'graphdb',
-      'vectordb',
-      'coldstorage',
-    ],
-  },
-  {
-    // How services talk when it is not one request calling one server:
-    // logs, topics, sockets, functions and jobs on a clock.
-    id: 'messaging',
-    title: 'Messaging',
-    kinds: ['streambroker', 'pubsub', 'websocket', 'lambda', 'cron'],
-  },
-  {
-    id: 'control',
-    title: 'Control',
-    kinds: [
-      'ratelimiter',
-      'loadshedder',
-      'breaker',
-      'bulkhead',
-      'autoscaler',
-      'region',
-      'apigateway',
-      'sidecar',
-    ],
-  },
-];
 
 /**
  * Shown as the row's `title` only. The prose that used to render under

--- a/src/components/nodeVisuals.groups.test.ts
+++ b/src/components/nodeVisuals.groups.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { KIND_GROUPS, KIND_ICON, groupOfKind } from './nodeVisuals';
+import type { NodeKind } from '../sim/types';
+
+/**
+ * Guards the taxonomy, which two surfaces now read.
+ *
+ * KIND_GROUPS decides both what the rail lists and what the canvas ledger
+ * counts. A kind missing from it is silent in each: the rail simply does not
+ * offer it, and the ledger's breakdown quietly sums to less than the total
+ * beside it. Nothing in a typecheck or a build says so, because a kind not
+ * mentioned anywhere is not a type error.
+ *
+ * KIND_ICON is used as the roster of kinds rather than a hand-written list,
+ * because it is a `Record<NodeKind, ...>` and so the typechecker already
+ * forces it to be exhaustive. Adding a kind therefore fails here until it is
+ * given a group, which is the point.
+ */
+const ALL_KINDS = Object.keys(KIND_ICON) as NodeKind[];
+
+describe('the kind taxonomy', () => {
+  it('gives every kind a group', () => {
+    const ungrouped = ALL_KINDS.filter((k) => groupOfKind(k) === undefined);
+    expect(ungrouped).toEqual([]);
+  });
+
+  it('puts no kind in two groups', () => {
+    const seen = new Map<NodeKind, string[]>();
+    for (const group of KIND_GROUPS) {
+      for (const kind of group.kinds) {
+        seen.set(kind, [...(seen.get(kind) ?? []), group.id]);
+      }
+    }
+    const duplicated = [...seen.entries()].filter(([, groups]) => groups.length > 1);
+    expect(duplicated).toEqual([]);
+  });
+
+  it('lists no kind that does not exist', () => {
+    const known = new Set<string>(ALL_KINDS);
+    const unknown = KIND_GROUPS.flatMap((g) => g.kinds).filter((k) => !known.has(k));
+    expect(unknown).toEqual([]);
+  });
+
+  /**
+   * The ledger prints `id`, not `title`, because "specialised stores" does not
+   * fit a corner that also holds two totals and a clock. That only reads as
+   * English while every id stays one lowercase word.
+   */
+  it('keeps every id printable as a name', () => {
+    for (const group of KIND_GROUPS) {
+      expect(group.id).toMatch(/^[a-z]+$/);
+    }
+  });
+});

--- a/src/components/nodeVisuals.ts
+++ b/src/components/nodeVisuals.ts
@@ -459,3 +459,88 @@ export function cellStrip(count: number, width: number, gap = 1.5): CellStrip {
   const w = Math.max(0.75, slot - g);
   return { x: (i: number) => i * slot, w, dense };
 }
+
+/* ------------------------------------------------------------------ *
+ * The kind taxonomy.
+ *
+ * Thirty-three kinds listed flat is a wall of names nobody reads. Grouped,
+ * each group answers one question, so a student looking for "how do I stop
+ * this melting" goes straight to Control without reading the other names.
+ * It is a lookup index, not decoration.
+ *
+ * It lives here rather than in Palette.tsx because the rail is no longer the
+ * only reader: the canvas ledger counts a design by group too, and a second
+ * copy of the taxonomy is how the two would drift. This module is already
+ * where per-kind presentation data lives (KIND_ICON, KIND_NAME, KIND_TERM),
+ * and it exports no components, so it is also the one of the two files that
+ * can export a constant without tripping `only-export-components`.
+ *
+ * `id` doubles as the short name. Every one of the six is a single word that
+ * reads correctly in running text, which is what the ledger prints where
+ * `title` would be too long ("stores", not "Specialised stores").
+ * ------------------------------------------------------------------ */
+
+export interface KindGroup {
+  id: string;
+  title: string;
+  kinds: NodeKind[];
+}
+
+export const KIND_GROUPS: KindGroup[] = [
+  { id: 'traffic', title: 'Traffic', kinds: ['client', 'lb', 'cdn', 'edgecompute'] },
+  {
+    id: 'compute',
+    title: 'Compute',
+    kinds: ['service', 'worker', 'queue', 'retryqueue', 'transcoder'],
+  },
+  {
+    id: 'data',
+    title: 'Data',
+    kinds: ['db', 'cache', 'writebehind', 'replica', 'shard'],
+  },
+  {
+    // The polyglot-persistence shelf: each of these exists because putting
+    // its workload in the main database is the mistake it teaches against.
+    id: 'stores',
+    title: 'Specialised stores',
+    kinds: [
+      'objectstore',
+      'searchindex',
+      'timeseriesdb',
+      'graphdb',
+      'vectordb',
+      'coldstorage',
+    ],
+  },
+  {
+    // How services talk when it is not one request calling one server:
+    // logs, topics, sockets, functions and jobs on a clock.
+    id: 'messaging',
+    title: 'Messaging',
+    kinds: ['streambroker', 'pubsub', 'websocket', 'lambda', 'cron'],
+  },
+  {
+    id: 'control',
+    title: 'Control',
+    kinds: [
+      'ratelimiter',
+      'loadshedder',
+      'breaker',
+      'bulkhead',
+      'autoscaler',
+      'region',
+      'apigateway',
+      'sidecar',
+    ],
+  },
+];
+
+/** Which group a kind belongs to, resolved once rather than scanned per call. */
+const GROUP_OF_KIND = new Map<NodeKind, KindGroup>();
+for (const group of KIND_GROUPS) {
+  for (const kind of group.kinds) GROUP_OF_KIND.set(kind, group);
+}
+
+export function groupOfKind(kind: NodeKind): KindGroup | undefined {
+  return GROUP_OF_KIND.get(kind);
+}


### PR DESCRIPTION
Closes #10.

The ledger said `21 COMPONENTS  17 CONNECTIONS  3.8s`. The total tells you how big a diagram is
but not what kind of system it is, which is the thing you're actually trying to work out when
you open a reconstruction you didn't build. Now it says:

```
21 COMPONENTS   6 TRAFFIC, 9 COMPUTE, 1 DATA, 2 STORES, 2 MESSAGING, 1 CONTROL   17 CONNECTIONS   3.8s
```

That's copied out of the running app with Discord loaded, not typed by hand.

**Where KIND_GROUPS went.** You offered exporting it from `Palette.tsx` or moving it to its own
module, and leaned towards the module. I did neither, it's in `nodeVisuals.ts`. That file is
already the kind-to-presentation table (`KIND_ICON`, `KIND_NAME`, `KIND_TERM`), it has no
components in it so exporting a constant doesn't trip `only-export-components`, and
`Palette.tsx:11` and `Canvas.tsx:37` were both importing from it already, so nothing gains an
import and nothing gains a file. A separate module felt like a fourth place for kind metadata to
live. Happy to split it out if you'd rather.

**A few calls in the line itself.** Groups print in taxonomy order rather than by count, so it
matches the rail and doesn't reshuffle every time you drop a node in. Empty groups are dropped,
because eleven of the twenty-three examples only touch three of the six and "0 messaging" on a
three-box chain is noise. And I print the group `id` rather than the `title`, since they're all
single words anyway and "SPECIALISED STORES" won't fit a corner that's also holding two totals
and a clock.

**The 1240px cutoff is measured.** I ran it in a browser rather than eyeballing it. Discord
gives the widest breakdown of any example, which puts the ledger at 737px ending at x=1029, and
the zoom cluster sits 181px in from the right edge, so they touch at a viewport of 1210. Checked
both sides:

| viewport | breakdown | ledger | zoom cluster | |
| --- | --- | --- | --- | --- |
| 2560 | shown | 292..1029 | 2379 | clear |
| 1440 | shown | 292..1029 | 1259 | clear |
| 1241 | shown | 292..1029 | 1060 | clear |
| 1240 | hidden | 292..567 | 1059 | clear |
| 960 | hidden | 292..567 | 787 | clear |

1150 and below collided before the cutoff existed. The totals stay at every width since they're
what you glance at, and the breakdown is the elaboration, so it's the right thing to drop first.
It's a separate rule from the clock's 720px because it's much longer and runs into the zoom
cluster rather than off the edge of the screen.

**One new test file.** `nodeVisuals.groups.test.ts`, because two surfaces read the taxonomy now
and a kind missing from `KIND_GROUPS` would be silent in both: the rail just wouldn't offer it,
and the ledger's breakdown would quietly sum to less than the total next to it. It walks
`KIND_ICON` rather than a hand-written list of kinds, since that's a `Record<NodeKind, ...>` and
the typechecker already keeps it exhaustive, so adding a kind fails here until you give it a
group.

`bun run test` is 859 passing. typecheck, lint and format:check clean, lint on the same 26
warnings as main.

The ledger is text so the line at the top is the whole visual change, but I've got a screenshot
of the 1440 case if you want it.
