### PR TITLE
ci: run the tests and build on Windows, not just Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # OS-independent gates. Typecheck, lint and format read the same bytes on
+  # every platform, so running them once on Linux is the whole coverage; a
+  # matrix here would re-run identical work at the slowest per-minute rate.
   check:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -42,6 +45,33 @@ jobs:
 
       - name: Format
         run: bun run format:check
+
+  # The suite and the build run on every OS the project supports. Linux alone
+  # missed a path bug that broke the whole suite on Windows (#16): the code the
+  # matrix actually exercises differently is drive letters and path separators.
+  # macOS is left out on purpose. It shares Unix path semantics with Linux, so
+  # against ubuntu it mostly re-runs the same code paths; add a third entry the
+  # day something turns out to be Darwin-specific.
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Install
+        run: bun install --frozen-lockfile
 
       - name: Test
         run: bun run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,9 +72,11 @@ Two git hooks are installed when you run `bun install`:
 - **On push**, the full CI suite runs locally: typecheck, lint, format, tests. If any of it fails
   the push is blocked, with the failure printed.
 
-This mirrors `.github/workflows/ci.yml` exactly, so a push that succeeds locally will not turn CI
-red. If you ever need to bypass a hook deliberately, `git push --no-verify` works, but expect CI to
-catch whatever the hook would have.
+This mirrors the checks in `.github/workflows/ci.yml`, with one gap: the hook runs on your machine
+only, while CI also runs the tests and the build on Windows. A push that is green locally can still
+turn CI red if a change is sensitive to path separators or drive letters. If you ever need to
+bypass a hook deliberately, `git push --no-verify` works, but expect CI to catch whatever the hook
+would have.
 
 ## How the project is laid out
 


### PR DESCRIPTION
## What this changes

Splits `.github/workflows/ci.yml` into two jobs:

- **`check`** (`ubuntu-latest`): typecheck, lint, format. OS-independent, so it runs once.
- **`test`** (`[ubuntu-latest, windows-latest]`, `fail-fast: false`): install, test, build.

Plus one line in CONTRIBUTING noting the pre-push hook is local-only.

Closes #18.

## Why

CI ran on `ubuntu-latest` alone, so a change that only misbehaves on another platform merged green. #16 / #17 was the worked example: `copy.dashes.test.ts` handed a `URL.pathname` string to `readdirSync`, which breaks on a Windows drive path (`/D:/...` resolves to `D:\D:\...`). The class is path handling; what a matrix covers on its own that a spaced Linux path does not is drive letters and separators.

Scope follows the discussion on #18:

- **macOS is left out.** It shares Unix path semantics with Linux, so against `ubuntu-latest` it mostly re-runs the same code paths at the slowest per-minute rate on the runner fleet. Adding a third matrix entry later is one line if something turns out to be Darwin-specific.
- **No `schedule:`.** Matrix-on-PR already covers toolchain drift for anything that lands. A scheduled-only run would let an OS-breaking PR merge and sit until the next cron, which is the #16 scenario.
- **CRLF is not addressed here.** If `prettier --check` fails on a CRLF checkout despite `.gitattributes`, that is a `.gitattributes` fix and its own issue, not something a matrix should paper over.
- `check` and `test` both keep `permissions: { contents: read }`, `persist-credentials: false`, and the pinned action SHAs.
- `build` stays in the matrix on purpose, so a Windows-only build break is caught too.

## Verification

- YAML parses; job graph is `check` + `test`, `test.runs-on` is `${{ matrix.os }}`, matrix is `[ubuntu-latest, windows-latest]`, `fail-fast: false`.
- `npx prettier --check .github/workflows/ci.yml CONTRIBUTING.md`: clean.
- `npx vitest run` (full suite, local, Linux-equivalent via npm): `32 files, 855 tests passed`. This PR changes only the workflow file and a doc paragraph, no runtime code.

- [x] tests pass locally
- [x] workflow YAML validated and formatted
- [ ] no code change, nothing visual

## Not verified

The Windows matrix leg itself. It will run on this PR; `oven-sh/setup-bun` and `bun install --frozen-lockfile` both support Windows, but I cannot exercise the hosted Windows runner from here. Hooks were bypassed with `--no-verify` because they call `bun`/`bunx`, which is not installed on my machine; `prettier --check` and the vitest suite were run through npm.