### PR TITLE
fix: keep client load stable across topology edits

### DIFF
--- a/src/sim/engine.test.ts
+++ b/src/sim/engine.test.ts
@@ -48,6 +48,58 @@ describe('determinism', () => {
     const b = JSON.stringify(run(structuredClone(topology), 12, 2));
     expect(a).not.toBe(b);
   });
+
+  it('keeps a retained client arrival stream across topology edits', () => {
+    const client = { ...makeNode('client', 0, 0), id: 'client' };
+    client.config = { ...client.config, rps: 50 };
+    const topology: Topology = { nodes: [client], edges: [] };
+    const untouched = new Engine(topology, 42);
+    const edited = new Engine(topology, 42);
+
+    for (let i = 0; i < 10; i += 1) edited.setTopology(topology);
+    for (let i = 0; i < 600; i += 1) {
+      untouched.advance(1000 / 60);
+      edited.advance(1000 / 60);
+    }
+
+    expect(edited.snapshot()).toEqual(untouched.snapshot());
+  });
+
+  it.each(['added', 'retyped'] as const)(
+    'starts an arrival stream for a %s client',
+    (change) => {
+      const original = { ...makeNode('service', 0, 0), id: 'source' };
+      const engine = new Engine(
+        change === 'added'
+          ? { nodes: [], edges: [] }
+          : {
+              nodes: [original],
+              edges: [],
+            },
+        42,
+      );
+      const client = { ...makeNode('client', 0, 0), id: 'source' };
+      client.config = { ...client.config, rps: 50 };
+
+      engine.setTopology({ nodes: [client], edges: [] });
+      for (let i = 0; i < 600; i += 1) engine.advance(1000 / 60);
+
+      expect(engine.snapshot().system.totalRequests).toBe(485);
+    },
+  );
+
+  it('replays the initial arrival stream after reset', () => {
+    const client = { ...makeNode('client', 0, 0), id: 'client' };
+    client.config = { ...client.config, rps: 50 };
+    const engine = new Engine({ nodes: [client], edges: [] }, 42);
+
+    for (let i = 0; i < 600; i += 1) engine.advance(1000 / 60);
+    const first = JSON.stringify(engine.snapshot());
+    engine.reset();
+    for (let i = 0; i < 600; i += 1) engine.advance(1000 / 60);
+
+    expect(JSON.stringify(engine.snapshot())).toBe(first);
+  });
 });
 
 describe.each(PRESETS.map((p) => [p.id, p] as const))('preset %s', (_id, preset) => {

--- a/src/sim/engine.ts
+++ b/src/sim/engine.ts
@@ -420,6 +420,8 @@ interface NodeState {
   totalCompleted: number;
   totalFailed: number;
 
+  /** Identifies the arrival stream for this incarnation of a load generator. */
+  arrivalGeneration: number;
   /** True once a worker poll event is scheduled, so we do not stack pollers. */
   pollScheduled: boolean;
   /**
@@ -498,6 +500,7 @@ export class Engine implements BehaviourCtx {
 
   private nodes = new Map<string, NodeState>();
   private clientIds: string[] = [];
+  private nextArrivalGeneration = 1;
   /**
    * Nodes whose behaviour declares onTick. Kept as a separate list so the
    * per-advance walk costs nothing at all while no such kind exists.
@@ -997,6 +1000,7 @@ export class Engine implements BehaviourCtx {
     this.rng = new Rng(this.seed);
     this.now = 0;
     this.seq = 0;
+    this.nextArrivalGeneration = 1;
     this.heap.clear();
     this.freeReq = null;
     this.freeEv.length = 0;
@@ -1058,6 +1062,7 @@ export class Engine implements BehaviourCtx {
 
   private buildNodes(previous: Map<string, NodeState> | null): void {
     const next = new Map<string, NodeState>();
+    const newClientIds: string[] = [];
     this.clientIds = [];
 
     for (const node of this.topology.nodes) {
@@ -1072,6 +1077,8 @@ export class Engine implements BehaviourCtx {
         state.sources = [];
       } else {
         state = createNodeState(node);
+        state.arrivalGeneration = this.nextArrivalGeneration++;
+        if (state.behaviour.generatesLoad) newClientIds.push(node.id);
       }
       state.lastIntegrateMs = this.now;
       next.set(node.id, state);
@@ -1131,8 +1138,9 @@ export class Engine implements BehaviourCtx {
     }
     this.edgeFlow = flow;
 
-    // Restart the generators/pollers; stale ones are ignored via node lookup.
-    for (const id of this.clientIds) {
+    // Retained clients keep their already scheduled arrival. Only a new or
+    // retyped client needs an initial event to start its generator.
+    for (const id of newClientIds) {
       this.scheduleArrival(id);
     }
     this.tickNodes = [];
@@ -1167,7 +1175,9 @@ export class Engine implements BehaviourCtx {
 
     switch (ev.kind) {
       case EV_ARRIVAL:
-        this.onClientArrival(state);
+        if (state.behaviour.generatesLoad && state.arrivalGeneration === ev.token) {
+          this.onClientArrival(state);
+        }
         break;
       case EV_SERVICE_DONE:
         if (ev.req && ev.req.token === ev.token) this.onServiceDone(state, ev.req);
@@ -1206,11 +1216,11 @@ export class Engine implements BehaviourCtx {
     if (!(rps > 0)) {
       // Poll again shortly so raising the slider, or a pattern coming back up
       // off its trough, resumes traffic.
-      this.push(this.now + 50, EV_ARRIVAL, nodeId, null, 0);
+      this.push(this.now + 50, EV_ARRIVAL, nodeId, null, state.arrivalGeneration);
       return;
     }
     const gap = this.rng.exponential(1000 / rps);
-    this.push(this.now + gap, EV_ARRIVAL, nodeId, null, 0);
+    this.push(this.now + gap, EV_ARRIVAL, nodeId, null, state.arrivalGeneration);
   }
 
   private onClientArrival(state: NodeState): void {
@@ -2659,6 +2669,7 @@ function createNodeState(node: SimNode): NodeState {
     latency: new LatencyRing(),
     totalCompleted: 0,
     totalFailed: 0,
+    arrivalGeneration: 0,
     pollScheduled: false,
     shardUtil: [],
     instanceUnits: [],


### PR DESCRIPTION
## What this changes

Structural topology edits now preserve the one scheduled arrival stream already owned by each retained client. Newly added or retyped clients still start normally, while per-incarnation generation tokens prevent stale events from removed or retyped clients from reviving against a reused node ID.

Closes #30.

## Why

Every `setTopology()` call previously scheduled another arrival event for every client without invalidating the existing event. Ten structural edits changed a configured 50 RPS client from 51.1111 measured RPS and 485 requests to 488.8889 RPS and 5,427 requests.

After this change, edited and untouched runs both produce 51.1111 measured RPS and 485 requests, with byte-identical snapshots. Reset also restores the generation state alongside the event heap and RNG, preserving deterministic replay.

## Verification

- [x] `bun run test` — 35 files and 884 tests passed
- [x] `bun run typecheck` — passed
- [x] `bun run lint` — passed with existing unrelated warnings
- [x] `bun run format:check` — passed
- [x] `bun run build` — 1,885 modules transformed
- [x] Structured autoreview — clean, no accepted/actionable findings
