### PR TITLE
fix: keep the offered-load slider still while saving

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -160,6 +160,7 @@
   flex: none;
   align-items: center;
   gap: var(--sp-1);
+  width: 56px;
   margin: 0;
   font-size: var(--fs-label);
   letter-spacing: var(--tr-label);


### PR DESCRIPTION
## What this changes

The save-status label now reserves 56 pixels whether it says `Saved` or `Saving`, so changing persistence state no longer moves the adjacent offered-load slider beneath the pointer. The existing `role="status"` markup and announcements are unchanged.

Closes #32.

| Before | After |
|:------:|:-----:|
| ![Before: Saving expands the brand island and shifts the load control](https://files.carlulsoe.com/2026/08/c0b67998ab25b46e-issue-32-before.png) | ![After: Saving occupies reserved width and the load control stays still](https://files.carlulsoe.com/2026/08/4a510340cfaa203d-issue-32-after.png) |

The screenshot URLs are temporary and expire after 30 days.

## Why

At a 1920×1080 viewport, the status grew from 50.265625 pixels for `Saved` to 55.5 pixels for `Saving`. The brand island, load island, and slider all moved by the same 5.234375 pixels during interaction. The slider itself did not resize.

With the reserved width, both states measure 56 pixels and the load island and slider move 0 pixels across the real React save transition.

## Verification

- [x] Matched Chromium base/head geometry at 1920×1080 — 5.234375 px before, 0 px after
- [x] Existing `role="status"` preserved
- [x] `bun run test` — 35 files and 880 tests passed
- [x] `bun run typecheck` — passed
- [x] `bun run lint` — passed with existing unrelated warnings
- [x] `bun run format:check` — passed
- [x] `bun run build` — 1,885 modules transformed
- [x] Structured autoreview — clean, no accepted/actionable findings
