### PR TITLE
docs: explain how vendor sizes become simulator numbers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,33 @@ Presets are the main teaching surface, so they get held to a standard:
 Do the arithmetic before tuning by feel: a node's ceiling is
 `capacity * instances * (1000 / serviceMs)` requests per second.
 
+## Adding a vendor size
+
+Vendor mode (`src/content/vendors/`) turns a published instance size, like `db.r6g.large`, into
+simulator config. Two kinds of file are involved, and they are kept strictly apart:
+
+- `aws.ts`, `gcp.ts`, `azure.ts` hold **published spec only**: vCPU, memory, network, price, each
+  with the URL it came from and, for prices, the date it was read. Every field here must be a fact
+  you can point at, not a guess.
+- `derive.ts` holds the **one model** that turns a spec into engine knobs (`capacity` and
+  `serviceMs`). It is the only place that mapping happens, and it makes one decision worth knowing
+  before you touch it: it derives `capacity` from vCPU, and it refuses to touch `serviceMs` at all.
+  A bigger machine does not make a query faster, it makes more queries run at once, so changing
+  `serviceMs` when someone picks a larger instance would teach the opposite of what this simulator
+  is for. `derive.test.ts` has the tests that pin that refusal down.
+
+What this means for adding a new vendor size:
+
+- Only add fields you can cite. If the vendor does not publish a number in readable text, leave the
+  field out rather than estimate it, the same way the existing files leave `vcpu` off an Azure
+  Managed Redis SKU that only states it inside an image. `derive.ts` already treats a missing vCPU
+  as "nothing honest to say" and skips the size rather than inventing a slot count.
+- A published `maxConnections` figure is a real ceiling, so where the vendor states one it is used
+  as-is and wins over the vCPU-based estimate. Where it does not, only `vcpu` feeds the estimate.
+- Do not add a mapping from size to `serviceMs`. There isn't one, on purpose; see above.
+- Follow the citation style already in `aws.ts`, `gcp.ts` and `azure.ts`: a `source` URL on every
+  size, and a `pricedOn` date on every price.
+
 ## Writing for students
 
 The audience is a first-year CS student who has not taken a queueing theory course.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,8 +158,10 @@ What this means for adding a new vendor size:
   field out rather than estimate it, the same way the existing files leave `vcpu` off an Azure
   Managed Redis SKU that only states it inside an image. `derive.ts` already treats a missing vCPU
   as "nothing honest to say" and skips the size rather than inventing a slot count.
-- A published `maxConnections` figure is a real ceiling, so where the vendor states one it is used
-  as-is and wins over the vCPU-based estimate. Where it does not, only `vcpu` feeds the estimate.
+- A published `maxConnections` figure is a real ceiling, so where the vendor states one, `derive.ts`
+  takes the smaller of it and the vCPU-based estimate (`Math.min`). It does not replace the vCPU
+  estimate, it only caps it: if vCPU already implies fewer slots than `maxConnections`, vCPU still
+  wins. Where the vendor does not state one, only `vcpu` feeds the estimate.
 - Do not add a mapping from size to `serviceMs`. There isn't one, on purpose; see above.
 - Follow the citation style already in `aws.ts`, `gcp.ts` and `azure.ts`: a `source` URL on every
   size, and a `pricedOn` date on every price.


### PR DESCRIPTION
Closes #13.

I read `derive.ts` and `types.ts` before writing this, so the doc match what the code really do.

`derive.ts` already explain, in its own comments, that capacity come from vcpu but `serviceMs` never change from a picked size, and why (bigger machine run more queries at once, it does not make one query faster). But a contributor adding a new vendor size would not find that unless they open `derive.ts` first. This PR moves the short version into CONTRIBUTING.md, next to the existing "Adding a preset" section, so it is where someone actually looks before writing a new vendor file.

The new section covers:
- the two kinds of vendor file (spec files like `aws.ts`, and the one model file `derive.ts`) and what belongs in each
- capacity comes from vcpu, `serviceMs` never does
- a missing field means leave it out, not a guess (matches the existing Azure Managed Redis example)
- `maxConnections` wins over the vcpu estimate when the vendor states one
- the citation style to follow: `source` URL on every size, `pricedOn` date on every price

No code changed, only `CONTRIBUTING.md`. I ran `bun run build` and `bun run test` before opening this, both pass (895 tests).