### PR TITLE
fix: changes the styling around the theme toggle button in settings t…

### DIFF
--- a/src/components/Settings.css
+++ b/src/components/Settings.css
@@ -190,6 +190,13 @@
 .st-seg.is-active {
   background: var(--surface);
   color: var(--text);
+  border: var(--bw) solid var(--border-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.st-seg.is-active-4 {
+  background: var(--surface);
+  color: var(--text);
   box-shadow: var(--shadow-sm);
 }
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -373,7 +373,7 @@ export function Settings({
                     type="button"
                     role="radio"
                     aria-checked={prefs.vendor === v.id}
-                    className={`st-seg${prefs.vendor === v.id ? ' is-active' : ''}`}
+                    className={`st-seg st-seg-4${prefs.vendor === v.id ? ' is-active-4' : ''}`}
                     onClick={() => setPreference('vendor', v.id)}
                   >
                     {v.label}


### PR DESCRIPTION
…o make it more visible.

## What this changes

Added border to st-seg.is-active and made a similar st-seg.is-active-4 with correspondence to .st-segmented-4 so that these changes don't affect component-name style.

## Why

Adds visual confirmation of which option is selected ( was very hard to distinguish before).

## Verification
Before
<img width="715" height="187" alt="image" src="https://github.com/user-attachments/assets/c33a5993-eae9-486b-883e-e8aa5c63890f" />
After
<img width="722" height="247" alt="image" src="https://github.com/user-attachments/assets/a4a8dd3f-6f70-42e1-913c-641d44982adf" />

- [x] `bun run test` passes. Note the `run`: plain `bun test` bypasses the jsdom setup and
      reports failures that are not real
- [x] `bun run typecheck` and `bun run lint` pass
- [x] `bun run build` passes
- [x] Screenshot attached, if anything visual changed
