### PR TITLE
fix: keep a design this build cannot open instead of erasing it

### DIFF
--- a/src/savedDesigns.rejected.test.ts
+++ b/src/savedDesigns.rejected.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  MAX_SAVED,
+  deleteDesign,
+  listDesigns,
+  renameDesign,
+  saveDesign,
+} from './savedDesigns';
+import { defaultConfig } from './sim/presets';
+import type { NodeKind, Topology } from './sim/types';
+
+/**
+ * A row this build cannot open must survive a write.
+ *
+ * Every mutation here is read, change, write, and the read drops what it
+ * cannot parse. That is right for display and wrong for storage: a row dropped
+ * on the way in used to be a row deleted on the way out, so saving an
+ * unrelated design erased someone else's permanently, with nothing said.
+ *
+ * The rows used below carry duplicate node ids, which is the shape a
+ * palette-add produces after a reload, so this is the case that actually
+ * happens rather than a hand-corrupted fixture.
+ */
+
+const KEY = 'breakscale.designs.v1';
+
+const node = (id: string, kind: NodeKind) => ({
+  id,
+  kind,
+  label: id,
+  x: 0,
+  y: 0,
+  config: defaultConfig(kind),
+});
+
+/** Rejected by isTopology: two nodes share an id. */
+const unreadable = {
+  nodes: [node('client', 'client'), node('cache-1', 'cache'), node('cache-1', 'cache')],
+  edges: [],
+} as unknown as Topology;
+
+const healthy: Topology = { nodes: [node('client', 'client')], edges: [] };
+
+function seed(rows: unknown[]): void {
+  localStorage.setItem(KEY, JSON.stringify(rows));
+}
+
+const rawRows = (): Record<string, unknown>[] =>
+  JSON.parse(localStorage.getItem(KEY) ?? '[]') as Record<string, unknown>[];
+
+const rawNames = (): unknown[] => rawRows().map((e) => e.name);
+
+beforeEach(() => {
+  localStorage.clear();
+  seed([
+    { id: 'a', name: 'Week 3 coursework', topology: unreadable, savedAt: 1 },
+    { id: 'b', name: 'Fine one', topology: healthy, savedAt: 2 },
+  ]);
+});
+
+describe('a design this build cannot open', () => {
+  it('is kept off the shelf, because it cannot be shown', () => {
+    expect(listDesigns().map((d) => d.name)).toEqual(['Fine one']);
+  });
+
+  it('survives an unrelated save', () => {
+    expect(saveDesign('Something new', healthy).ok).toBe(true);
+    expect(rawNames()).toContain('Week 3 coursework');
+  });
+
+  it('survives deleting a different design', () => {
+    deleteDesign('b');
+    expect(rawNames()).toContain('Week 3 coursework');
+  });
+
+  it('survives renaming a different design', () => {
+    expect(renameDesign('b', 'Renamed')).toBe(true);
+    expect(rawNames()).toContain('Week 3 coursework');
+  });
+
+  it('survives being saved over by name, which only replaces what it matches', () => {
+    saveDesign('Fine one', healthy);
+    expect(rawNames()).toContain('Week 3 coursework');
+    expect(listDesigns()).toHaveLength(1);
+  });
+
+  it('comes back byte for byte, so a later build can still open it', () => {
+    const before = rawRows().find((e) => e.id === 'a');
+    saveDesign('Something new', healthy);
+    const after = rawRows().find((e) => e.id === 'a');
+    expect(after).toEqual(before);
+  });
+});
+
+describe('the readable half is unaffected', () => {
+  it('still saves, renames and deletes normally', () => {
+    expect(saveDesign('Second', healthy).ok).toBe(true);
+    expect(
+      listDesigns()
+        .map((d) => d.name)
+        .sort(),
+    ).toEqual(['Fine one', 'Second']);
+    expect(renameDesign('b', 'Renamed')).toBe(true);
+    expect(
+      listDesigns()
+        .map((d) => d.name)
+        .sort(),
+    ).toEqual(['Renamed', 'Second']);
+    deleteDesign('b');
+    expect(listDesigns().map((d) => d.name)).toEqual(['Second']);
+  });
+
+  it('still evicts the oldest at the cap, counting only what it can open', () => {
+    localStorage.clear();
+    seed([{ id: 'x', name: 'unopenable', topology: unreadable, savedAt: 0 }]);
+    for (let i = 0; i < MAX_SAVED; i += 1) saveDesign(`d${i}`, healthy);
+
+    expect(listDesigns()).toHaveLength(MAX_SAVED);
+    const last = saveDesign('one more', healthy);
+    expect(last.ok && last.evicted).toBe('d0');
+    expect(listDesigns()).toHaveLength(MAX_SAVED);
+    expect(rawNames()).toContain('unopenable');
+  });
+});
+
+describe('rows nobody can open do not grow without limit', () => {
+  it('keeps at most MAX_SAVED of them', () => {
+    localStorage.clear();
+    seed(
+      Array.from({ length: MAX_SAVED + 15 }, (_, i) => ({
+        id: `u${i}`,
+        name: `u${i}`,
+        topology: unreadable,
+        savedAt: i,
+      })),
+    );
+    saveDesign('mine', healthy);
+    expect(rawRows()).toHaveLength(MAX_SAVED + 1);
+  });
+});

--- a/src/savedDesigns.ts
+++ b/src/savedDesigns.ts
@@ -97,22 +97,56 @@ function parseEntry(raw: unknown): SavedDesign | null {
   };
 }
 
-/** Everything on the shelf, newest first. */
-export function loadDesigns(): SavedDesign[] {
+/**
+ * The shelf as it actually sits in storage: the rows this version understands,
+ * and the rows it does not.
+ *
+ * The second list is why this exists. Dropping a row that fails to parse is
+ * right for DISPLAY, but every mutation here is read, change, write, so a row
+ * dropped on the way in is a row deleted on the way out. Saving an unrelated
+ * design was enough to erase someone else's, permanently, with nothing said.
+ *
+ * So the unreadable rows are carried through verbatim. A row this build cannot
+ * open is not necessarily a row that is gone: it may be a newer format, or a
+ * design tripped by a bug that a later build fixes. Keeping the bytes leaves
+ * that recovery possible; rewriting the shelf without them does not.
+ */
+interface Shelf {
+  designs: SavedDesign[];
+  /** Rows that failed to parse, exactly as stored. Never inspected further. */
+  unreadable: unknown[];
+}
+
+function readShelf(): Shelf {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
+    if (!raw) return { designs: [], unreadable: [] };
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed
-      .map(parseEntry)
-      .filter((d): d is SavedDesign => d !== null)
-      .sort((a, b) => b.savedAt - a.savedAt);
+    if (!Array.isArray(parsed)) return { designs: [], unreadable: [] };
+
+    const designs: SavedDesign[] = [];
+    const unreadable: unknown[] = [];
+    for (const row of parsed) {
+      const entry = parseEntry(row);
+      if (entry) designs.push(entry);
+      // Bounded for the same reason MAX_SAVED exists: localStorage is a
+      // shared 5MB budget, and rows nobody can open must not grow without
+      // limit. Past the cap the oldest bytes go, which is the same trade the
+      // readable half already makes.
+      else if (unreadable.length < MAX_SAVED) unreadable.push(row);
+    }
+    designs.sort((a, b) => b.savedAt - a.savedAt);
+    return { designs, unreadable };
   } catch {
     // Corrupt JSON or blocked storage. An empty shelf is a survivable
     // outcome; a thrown error during boot is not.
-    return [];
+    return { designs: [], unreadable: [] };
   }
+}
+
+/** Everything on the shelf this build can open, newest first. */
+export function loadDesigns(): SavedDesign[] {
+  return readShelf().designs;
 }
 
 /** The list the interface renders, without the topologies. */
@@ -125,9 +159,12 @@ export function listDesigns(): SavedSummary[] {
   }));
 }
 
-function write(designs: SavedDesign[]): boolean {
+function write(designs: SavedDesign[], unreadable: readonly unknown[]): boolean {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(designs));
+    // The rows we could not parse go back untouched, after the ones we could.
+    // Order among them does not matter: nothing reads them, and the readable
+    // half is sorted on the way in.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...designs, ...unreadable]));
     return true;
   } catch {
     // Quota exceeded, or storage disabled. Reported rather than swallowed:
@@ -151,7 +188,7 @@ export function saveDesign(name: string, topology: Topology): SaveResult {
   const clean = name.trim().slice(0, MAX_NAME);
   if (!clean) return { ok: false, error: 'Give the design a name first.' };
 
-  const designs = loadDesigns();
+  const { designs, unreadable } = readShelf();
   const existing = designs.findIndex(
     (d) => d.name.toLowerCase() === clean.toLowerCase(),
   );
@@ -173,7 +210,7 @@ export function saveDesign(name: string, topology: Topology): SaveResult {
     next.length = MAX_SAVED;
   }
 
-  if (!write(next)) {
+  if (!write(next, unreadable)) {
     return {
       ok: false,
       error: 'There is no room left in this browser to save another design.',
@@ -188,14 +225,18 @@ export function getDesign(id: string): SavedDesign | null {
 }
 
 export function deleteDesign(id: string): void {
-  write(loadDesigns().filter((d) => d.id !== id));
+  const { designs, unreadable } = readShelf();
+  write(
+    designs.filter((d) => d.id !== id),
+    unreadable,
+  );
 }
 
 /** Rename in place. Returns false when the name is empty or already taken. */
 export function renameDesign(id: string, name: string): boolean {
   const clean = name.trim().slice(0, MAX_NAME);
   if (!clean) return false;
-  const designs = loadDesigns();
+  const { designs, unreadable } = readShelf();
   if (
     designs.some((d) => d.id !== id && d.name.toLowerCase() === clean.toLowerCase())
   ) {
@@ -203,7 +244,7 @@ export function renameDesign(id: string, name: string): boolean {
   }
   const i = designs.findIndex((d) => d.id === id);
   if (i < 0) return false;
-  return write(designs.with(i, { ...designs[i]!, name: clean }));
+  return write(designs.with(i, { ...designs[i]!, name: clean }), unreadable);
 }
 
 /**


### PR DESCRIPTION
Closes #53.

Every mutation on the shelf is read, change, write, and the read drops rows that fail to parse.
That is right for display and wrong for storage: a row dropped on the way in was a row deleted on
the way out. Saving an unrelated design erased someone else's, permanently, and so did renaming or
deleting a different one. Deleting one row of two wiped both.

Measured before, two rows with the first unopenable:

```
raw storage                    [ "Week 3 coursework", "Fine one" ]
saveDesign("Something new")    [ "Something new", "Fine one" ]
deleteDesign("b")              [ ]
```

After, the unopenable row is still there in both cases, byte for byte.

## What changed

`readShelf` returns what parsed and what did not, and `saveDesign`, `deleteDesign` and
`renameDesign` carry the second half back into storage untouched. `parseEntry` is unchanged and
still does one job; `loadDesigns` keeps its signature and is now `readShelf().designs`.

The rows come back identical rather than normalised, which is the point of keeping them. A row
this build cannot open is not necessarily a row that is gone: it may be a newer format, or a
design tripped by a bug a later build fixes. That is the case for the duplicate-id designs in #46,
where the bug costs the design and this one made the loss permanent.

The unreadable half is capped at `MAX_SAVED`, for the same reason the readable half is. Rows
nobody can open must not grow without limit in a shared 5MB budget, and past the cap the oldest
bytes go, which is the trade the readable half already makes.

## What I did not change

The shelf still does not show these rows, because there is nothing useful to render for one. It
is worth deciding separately whether a row that says it cannot be opened would be better than a
row that is simply absent, since silence is what made this invisible in the first place. That is a
copy and design question rather than a storage one, so it is not in here.

## Tests

`savedDesigns.rejected.test.ts`, nine cases. The fixture is a topology with duplicate node ids,
which is the shape a palette-add produces after a reload, so this is the failure that actually
happens rather than hand-corrupted JSON.

It pins that such a row stays off the shelf, survives a save, a rename, a delete and a
save-over-by-name, and comes back identical; that the readable half still saves, renames, deletes
and evicts at the cap as before; and that the unreadable half stays bounded.

Seven of the nine fail when the old read is put back. The two that pass are the two that should:
the row is still hidden, and the readable half still behaves. Checked by reverting.

904 tests pass. typecheck, lint and format:check clean, lint on the same 26 warnings as main.
