### PR TITLE
fix(sim): bound the instance count the engine will act on

### DIFF
--- a/src/sim/engine.instances.test.ts
+++ b/src/sim/engine.instances.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { Engine } from './engine';
+import { makeNode } from './presets';
+import type { NodeStats, Topology } from './types';
+
+/*
+ * `instances` reaches the engine from places that are not the inspector: a
+ * shared link, a `.breakscale` file and a restored session all carry it
+ * through, and `isTopology` checks nine core numbers and not this one. The
+ * engine writes one array element per instance on every snapshot, so what it
+ * does with a number the editor could never produce is a property of the
+ * engine rather than of the form that fed it.
+ */
+
+function topology(instances: unknown): Topology {
+  const client = { ...makeNode('client', 0, 0), id: 'client' };
+  client.config = { ...client.config, rps: 100 };
+  const target = { ...makeNode('service', 200, 0), id: 'target' };
+  target.config = { ...target.config, instances } as typeof target.config;
+  return {
+    nodes: [client, target],
+    edges: [{ id: 'client->target', from: 'client', to: 'target', weight: 1 }],
+  };
+}
+
+function unitsFor(instances: unknown): number {
+  const engine = new Engine(topology(instances), 7);
+  for (let i = 0; i < 30; i += 1) engine.advance(1000 / 60);
+  const stats = engine.snapshot().nodes['target'] as NodeStats | undefined;
+  return stats?.instances ?? -1;
+}
+
+describe('the instance count the engine will act on', () => {
+  it('is one when the design carries no number at all', () => {
+    expect(unitsFor(undefined)).toBe(1);
+  });
+
+  it('is one for a value that is not a number', () => {
+    // Math.max(1, Math.floor(NaN)) is NaN, and `units.length = NaN` throws.
+    expect(unitsFor(Number.NaN)).toBe(1);
+    expect(unitsFor(Number.POSITIVE_INFINITY)).toBe(1);
+  });
+
+  it('is one for a count below one', () => {
+    expect(unitsFor(0)).toBe(1);
+    expect(unitsFor(-4)).toBe(1);
+  });
+
+  it('takes the whole machines out of a fractional count', () => {
+    expect(unitsFor(2.7)).toBe(2);
+  });
+
+  it('stops at the ceiling the inspector offers, rather than allocating', () => {
+    // A design asking for a billion machines used to allocate a billion array
+    // elements on the first snapshot, which takes the tab with it.
+    const started = Date.now();
+    expect(unitsFor(1e9)).toBe(512);
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+});

--- a/src/sim/engine.ts
+++ b/src/sim/engine.ts
@@ -31,6 +31,15 @@ const MAX_DELTA_MS = 100;
 const MAX_EVENTS_PER_ADVANCE = 60000;
 /** Hop-depth ceiling; deeper resolves as FailureReason 'depth'. */
 const MAX_HOP_DEPTH = 32;
+/**
+ * Instance-count ceiling, matching the inspector's own slider.
+ *
+ * The engine writes one array element per instance on every snapshot, so an
+ * unbounded count is an unbounded allocation. A design does not only come from
+ * the editor: a shared link, a `.breakscale` file and a restored session all
+ * carry `instances` straight through, and `isTopology` does not police it.
+ */
+const MAX_INSTANCES = 512;
 /** Trailing window for latency percentiles. */
 const LATENCY_WINDOW_MS = 5000;
 /** Capacity of each latency ring buffer. */
@@ -2202,7 +2211,10 @@ export class Engine implements BehaviourCtx {
    */
   effectiveInstances(state: NodeStateLike): number {
     const raw = state.config.instances;
-    return raw === undefined ? 1 : Math.max(1, Math.floor(raw));
+    // `Math.max(1, Math.floor(NaN))` is NaN, so the ">= 1" above was a promise
+    // this could not keep, and `units.length = NaN` throws where it is read.
+    if (raw === undefined || !Number.isFinite(raw)) return 1;
+    return Math.min(MAX_INSTANCES, Math.max(1, Math.floor(raw)));
   }
 
   countHit(state: NodeStateLike): void {


### PR DESCRIPTION
## What

A design carrying a large `instances` takes the tab down on the first snapshot, and one carrying a
non-numeric `instances` throws.

`effectiveInstances` promises ">= 1" in its own doc comment, and cannot keep it:

```ts
effectiveInstances(state: NodeStateLike): number {
  const raw = state.config.instances;
  return raw === undefined ? 1 : Math.max(1, Math.floor(raw));
}
```

`Math.floor(NaN)` is `NaN` and `Math.max(1, NaN)` is `NaN`. The one caller that matters then does

```ts
units.length = instances;   // engine.ts, fillSlotInstances
```

which throws `RangeError: Invalid array length` for `NaN` and for `Infinity`, and allocates that many
elements for a large finite number. `snapshot()` runs at 10Hz, so it is the first frame that dies.

## Where it comes from

Not from the inspector: its slider stops at 512. It comes from every other way a design arrives.
`isTopology` checks nine core config numbers are finite — `capacity`, `serviceMs`, `serviceCv`,
`queueLimit`, `hitRate`, `errorRate`, `timeoutMs`, `retries`, `rps` — and says nothing about
`instances`, so a shared link, a `.breakscale` file and a restored session all carry it straight
through.

That makes it a link anyone can send. `decodeTopology` says of itself:

> Never throws and never returns something the engine cannot run

It defends against a payload that inflates without bound, and then hands over a number that makes
the engine allocate without bound.

Measured, running the decoded topology through the engine:

```
instances       what happens on the first snapshot
1e9             the process is killed
NaN             RangeError: Invalid array length
Infinity        RangeError: Invalid array length
```

The `1e9` case is not a slow frame. Running the new test file against `main`, the vitest worker
does not report a failure, it exits:

```
Caused by: Error: Worker exited unexpectedly
 Test Files   (1)
      Tests   (5)
     Errors  1 error
```

## Fix

`effectiveInstances` keeps its promise. Anything that is not a finite number is one instance, and
the count is capped at `MAX_INSTANCES = 512`, which is the ceiling the inspector already offers, so
nothing a reader can build changes.

Bounding it in the engine rather than in `isTopology` puts the guard on the seam every path shares.
A design reaches the engine from the editor, a link, a file and a restored session, and only one of
those goes through the validator.

## Tests

`src/sim/engine.instances.test.ts`, new, on the published `instances` count:

- absent is one instance, which is the additive default the field is documented to have
- `NaN` and `Infinity` are one instance rather than a throw
- `0` and `-4` are one instance
- `2.7` is two, since a fractional machine is not a machine
- `1e9` is 512, and the snapshot returns in well under a second

Against `main` the file cannot finish: the last of those kills the worker.

## How I tested

Windows 11, Bun 1.3.14. `bun run test` is 916 passed, up from 911 by the five new tests, with
nothing else moving. `bun run typecheck` and `bun run format:check` are clean, and `bun run lint`
reports the same one pre-existing warning in `Metrics.tsx` as it does on `main`.

I have not touched the inspector or the validator. If you would rather `isTopology` also refuse a
design like this, that is a separate change and I am happy to write it; this one is the guard that
holds wherever the design came from.
