### PR TITLE
docs: add a one-click hosted option to Getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ bun dev
 Open http://localhost:5173, pick an example from the left, and raise the traffic slider until
 something goes red.
 
+Or open it hosted, without installing Bun:
+
+[![Deploy on InstaPods](https://instapods.com/deploy-button.svg)](https://app.instapods.com/dashboard/pods/create?repo=https://github.com/xevrion/breakscale&ref=gh-breakscale)
+
 ## Features
 
 - **33 components.** Load balancers, caches, databases, queues and workers, plus CDNs, rate


### PR DESCRIPTION
I wanted to play with the simulator without installing Bun, so I deployed the repo as it is and it built and ran first try. Here it is running: https://b3-breakscale.fr-2.instapods.app

The link below does the same for anyone else: clone, build, serve over HTTPS. No config, no keys.

Two things I should be straight about. I work on InstaPods, so this is not a neutral suggestion. And your CONTRIBUTING asks for an issue first on anything touching the engine or components, which this is not, but if you would rather these came through an issue anyway, say so and I will not do it again. Closing this is completely fine either way.