### PR TITLE
fix(sim): keep a region switch routing when its numbers are not numbers

### DIFF
--- a/src/sim/behaviour-control.region.test.ts
+++ b/src/sim/behaviour-control.region.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { Engine } from './engine';
+import { makeNode } from './presets';
+import type { NodeStats, Topology } from './types';
+
+/*
+ * `regions` and `activeRegion` are not among the nine config numbers
+ * `isTopology` checks, so a shared link, a `.breakscale` file and a restored
+ * session carry whatever they say into the region switch.
+ */
+
+function topology(patch: Record<string, unknown>): Topology {
+  const client = { ...makeNode('client', 0, 0), id: 'client' };
+  client.config = { ...client.config, rps: 60 };
+  const region = { ...makeNode('region', 200, 0), id: 'r' };
+  region.config = { ...region.config, ...patch } as typeof region.config;
+  const east = { ...makeNode('service', 400, 0), id: 'east' };
+  const west = { ...makeNode('service', 400, 120), id: 'west' };
+  return {
+    nodes: [client, region, east, west],
+    edges: [
+      { id: 'e1', from: 'client', to: 'r', weight: 1 },
+      { id: 'e2', from: 'r', to: 'east', weight: 1 },
+      { id: 'e3', from: 'r', to: 'west', weight: 1 },
+    ],
+  };
+}
+
+function run(patch: Record<string, unknown>) {
+  const engine = new Engine(topology(patch), 7);
+  for (let i = 0; i < 200; i += 1) engine.advance(1000 / 60);
+  const snapshot = engine.snapshot();
+  return {
+    region: snapshot.nodes['r'] as NodeStats,
+    east: snapshot.nodes['east'] as NodeStats,
+    west: snapshot.nodes['west'] as NodeStats,
+  };
+}
+
+describe('a region switch given numbers the editor cannot produce', () => {
+  it('still routes when the active region is not a number', () => {
+    // `Math.floor(NaN)` is NaN and every comparison against it is false, so
+    // NaN used to be adopted as the live region -- and `out[NaN]` is nothing,
+    // so the switch served no region at all.
+    const { region, east, west } = run({ activeRegion: Number.NaN });
+    expect(Number.isNaN(region.activeRegion as number)).toBe(false);
+    expect(east.totalCompleted + west.totalCompleted).toBeGreaterThan(0);
+    expect(region.totalFailed).toBe(0);
+  });
+
+  it('counts its regions when the declared count is not a number', () => {
+    // The census loop runs `i < count`, which is false immediately for NaN,
+    // so the node reported no healthy region while it was serving one.
+    const { region } = run({ regions: Number.NaN });
+    expect(Number.isNaN(region.regionsTotal as number)).toBe(false);
+    expect(region.regionsHealthy).toBe(2);
+  });
+
+  it('keeps the readout and the routing agreeing', () => {
+    // decorateStats builds the census from the same predicate pickEdge routes
+    // with, so a node that is serving traffic cannot report zero healthy
+    // regions. That is the invariant the NaN broke.
+    const { region, east, west } = run({ regions: Number.NaN });
+    expect(east.totalCompleted + west.totalCompleted).toBeGreaterThan(0);
+    expect(region.regionsHealthy).toBeGreaterThan(0);
+  });
+
+  it('leaves a design the editor can produce exactly where it was', () => {
+    const plain = run({});
+    const explicit = run({ regions: 2, activeRegion: 0 });
+    expect(plain.region.regionsTotal).toBe(2);
+    expect(plain.region.activeRegion).toBe(0);
+    expect(explicit.east.totalCompleted).toBe(plain.east.totalCompleted);
+  });
+
+  it('still honours a second region the student selected', () => {
+    const { east, west } = run({ activeRegion: 1 });
+    expect(west.totalCompleted).toBeGreaterThan(0);
+    expect(east.totalCompleted).toBe(0);
+  });
+});

--- a/src/sim/behaviour-control.ts
+++ b/src/sim/behaviour-control.ts
@@ -394,8 +394,28 @@ function asRegion(state: NodeStateLike): RegionState | null {
 
 /** How many of this node's out edges count as regions. */
 function regionCount(state: NodeStateLike): number {
-  const declared = Math.floor(state.config.regions ?? state.out.length);
-  return Math.max(1, Math.min(declared, state.out.length));
+  const declared = state.config.regions;
+  // NaN fails every comparison, so `Math.min` and `Math.max` hand it back
+  // unchanged. It is then published as the region total, while the census
+  // loop that counts healthy regions runs zero times -- and the readout is
+  // meant to be derived from the very predicate the routing uses.
+  if (!Number.isFinite(declared)) return state.out.length;
+  return Math.max(1, Math.min(Math.floor(declared as number), state.out.length));
+}
+
+/**
+ * The region the student asked for, clamped into the regions that exist.
+ *
+ * A value that is not a finite number is the first region rather than
+ * itself: `Math.floor(NaN)` is NaN, every comparison below is false for it,
+ * so it used to be adopted as the live region -- and `out[NaN]` is nothing,
+ * which makes the switch route nowhere at all.
+ */
+function configuredRegion(state: NodeStateLike, count: number): number {
+  const raw = state.config.activeRegion;
+  if (!Number.isFinite(raw)) return 0;
+  const configured = Math.floor(raw as number);
+  return configured < 0 ? 0 : configured >= count ? count - 1 : configured;
 }
 
 /**
@@ -476,8 +496,7 @@ const region: ComponentBehaviour = {
     // between it and the live region -- after a failover the two differ by
     // design, and treating that as a manual switch would drag traffic back
     // onto the region that just died.
-    const configured = Math.floor(cfg.activeRegion ?? 0);
-    const wanted = configured < 0 ? 0 : configured >= count ? count - 1 : configured;
+    const wanted = configuredRegion(state, count);
     if (st.active === -1 || wanted !== st.lastConfigured) {
       st.lastConfigured = wanted;
       st.active = wanted;
@@ -606,8 +625,7 @@ function liveRegionIndex(
   const active = st.failoverDueMs >= 0 ? st.failoverTarget : st.active;
   if (active < 0) {
     // Nothing has been adopted yet; pickEdge would take the configured region.
-    const configured = Math.floor(state.config.activeRegion ?? 0);
-    const wanted = configured < 0 ? 0 : configured >= count ? count - 1 : configured;
+    const wanted = configuredRegion(state, count);
     return regionHealthy(ctx, state, wanted) ? wanted : -1;
   }
 


### PR DESCRIPTION
## What

Two numbers on the region node are read with `Math.floor` and then compared, and NaN fails every
comparison, so it survives both readings intact. One of them takes the switch off the air; the other
makes the panel contradict the routing it is derived from.

```ts
const declared = Math.floor(state.config.regions ?? state.out.length);
return Math.max(1, Math.min(declared, state.out.length));   // NaN in, NaN out

const configured = Math.floor(cfg.activeRegion ?? 0);
const wanted = configured < 0 ? 0 : configured >= count ? count - 1 : configured;   // NaN
```

## Measured

One client, one region node, two regions behind it. 200 ticks:

```
config                  activeRegion  regionsTotal  regionsHealthy   east   west   failed
(baseline)                         0             2               2    208      0        0
regions: NaN                       0           NaN               0    208      0        0
activeRegion: NaN                NaN             2               2      0      0      170
```

**`activeRegion: NaN`** is an outage. NaN is adopted as the live region, `state.out[NaN]` is nothing,
so `regionHealthy` is false forever and the switch serves neither region. Every request fails.

**`regions: NaN`** is quieter and, I think, the more interesting one. `regionsTotal` reaches the panel
as `NaN` and `regionsHealthy` reads 0, because the census is a loop and `i < NaN` is false on the
first test. Routing is unaffected — 208 requests are served — so the node reports "0 of NaN regions
healthy" while it is healthily serving one. `decorateStats` says of that census:

> from the same predicate pickEdge routes with, so the readout and the routing can never disagree
> about reachability

which is exactly the property NaN removes.

## Where it comes from

Not the inspector: `regions` is a number input bounded 1..8 and `activeRegion` 0..7. `isTopology`
checks the nine core config numbers — `capacity`, `serviceMs`, `serviceCv`, `queueLimit`, `hitRate`,
`errorRate`, `timeoutMs`, `retries`, `rps` — and neither of these, so a shared link, a `.breakscale`
file and a restored session carry them through untouched.

## Fix

`regionCount` falls back to the edge count for anything that is not a finite number, which is the
same thing an absent `regions` already means.

The two places that clamp `activeRegion` were the same four lines written twice; they are now one
`configuredRegion` helper, which rejects a non-finite value as the first region. Deduplicating them
is not incidental — the second copy is in `liveRegionIndex`, whose whole job is to answer exactly
what `pickEdge` would do, so the two must not be able to drift.

## Tests

`src/sim/behaviour-control.region.test.ts`, new:

- an `activeRegion` of `NaN` still routes, publishes a real region index and fails nothing
- a `regions` of `NaN` publishes a real total and counts both regions healthy
- the readout and the routing agree: a node serving traffic cannot report zero healthy regions
- an unset design and an explicit `{ regions: 2, activeRegion: 0 }` produce identical completions,
  which is the check that nothing a reader can build moved
- `activeRegion: 1` still sends everything to the second region

Against `main`, three of the five fail:

```
× still routes when the active region is not a number
× counts its regions when the declared count is not a number
× keeps the readout and the routing agreeing
AssertionError: expected true to be false
AssertionError: expected 0 to be greater than 0
```

## How I tested

Windows 11, Bun 1.3.14. `bun run test` is 934 passed across 40 files, up from 929 by the five new
tests, with nothing else moving. `bun run typecheck` and `bun run format:check` are clean, and
`bun run lint` reports the same pre-existing warnings in `useVendor.ts`, `Examples.tsx` and
`Tooltip.tsx` as `main` does.

Same family as #58, #60, #61 and #62, but this one is not about allocation: the region node's numbers
are small, and what NaN costs here is the routing and the readout rather than the process.
