### PR TITLE
fix: never mint a node id that is already on the canvas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1478,23 +1478,22 @@ export default function App() {
 
   const handleAddNode = useCallback(
     (kind: NodeKind, x: number, y: number) => {
-      // Pass the ids already on the canvas so a fresh page load cannot
-      // mint an id a restored design is already using (see makeNode).
-      const node = makeNode(
-        kind,
-        x,
-        y,
-        undefined,
-        new Set(topology.nodes.map((n) => n.id)),
-      );
+      // Read the live mirror, not the React binding: two adds in quick
+      // succession both run against the closure's pre-add snapshot, so the
+      // second would build on a topology missing the first node and drop
+      // it (see topoLiveRef, and #47 which found the stale closure first).
+      // The mirror also supplies the ids already on the canvas, so a fresh
+      // page load cannot mint an id a restored design is using (makeNode).
+      const t = topoLiveRef.current;
+      const node = makeNode(kind, x, y, undefined, new Set(t.nodes.map((n) => n.id)));
       history.commit('add', snapRef.current);
       applyTopology({
-        ...topology,
-        nodes: [...topology.nodes, node],
+        ...t,
+        nodes: [...t.nodes, node],
       });
       setSelectedIds(new Set([node.id]));
     },
-    [applyTopology, topology, history],
+    [applyTopology, history],
   );
 
   /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1478,7 +1478,15 @@ export default function App() {
 
   const handleAddNode = useCallback(
     (kind: NodeKind, x: number, y: number) => {
-      const node = makeNode(kind, x, y);
+      // Pass the ids already on the canvas so a fresh page load cannot
+      // mint an id a restored design is already using (see makeNode).
+      const node = makeNode(
+        kind,
+        x,
+        y,
+        undefined,
+        new Set(topology.nodes.map((n) => n.id)),
+      );
       history.commit('add', snapRef.current);
       applyTopology({
         ...topology,

--- a/src/sim/makeNode.ids.test.ts
+++ b/src/sim/makeNode.ids.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { makeNode } from './presets';
+
+describe('makeNode', () => {
+  it('never reuses an id that is already on the canvas', () => {
+    // A design restored after a reload carries ids minted by an earlier
+    // session, while the module counter has restarted from zero.
+    const taken = new Set(Array.from({ length: 10 }, (_, i) => `service-${i + 1}`));
+    const added = makeNode('service', 0, 0, undefined, taken);
+    expect(taken.has(added.id)).toBe(false);
+    expect(added.id).toMatch(/^service-\d+$/);
+  });
+
+  it('keeps minting distinct ids across repeated adds', () => {
+    const taken = new Set<string>(['cache-1', 'cache-2', 'cache-3']);
+    const seen = new Set<string>();
+    for (let i = 0; i < 5; i += 1) {
+      const n = makeNode('cache', 0, 0, undefined, taken);
+      expect(taken.has(n.id)).toBe(false);
+      expect(seen.has(n.id)).toBe(false);
+      seen.add(n.id);
+      taken.add(n.id);
+    }
+  });
+});

--- a/src/sim/presets.ts
+++ b/src/sim/presets.ts
@@ -652,15 +652,32 @@ const DEFAULT_LABEL: Record<NodeKind, string> = {
 
 let nodeCounter = 0;
 
+/**
+ * Mint a node for the canvas.
+ *
+ * `taken` is the set of ids already on the canvas. It has to be consulted:
+ * the counter above restarts at zero on every page load, while the ids it
+ * minted in earlier sessions come back through localStorage, share links
+ * and design files. Without the check the eleventh service added after a
+ * reload is `service-1` again, and two nodes then share one id: selecting
+ * either selects both, the inspector reads "2 components", edges drawn to
+ * one land on both, and a config change applies to both. The paste path
+ * already dedupes this way (clipboard.ts freshId); the add path did not.
+ */
 export function makeNode(
   kind: NodeKind,
   x: number,
   y: number,
   label?: string,
+  taken?: ReadonlySet<string>,
 ): SimNode {
-  nodeCounter += 1;
+  let id: string;
+  do {
+    nodeCounter += 1;
+    id = `${kind}-${nodeCounter}`;
+  } while (taken !== undefined && taken.has(id));
   return {
-    id: `${kind}-${nodeCounter}`,
+    id,
     kind,
     label: label ?? DEFAULT_LABEL[kind],
     x,


### PR DESCRIPTION
Adding a component from the palette could reuse an id that a node on the canvas already had. `makeNode` numbers new nodes from a module counter that restarts at zero on every page load, while the ids it minted in earlier sessions come back through localStorage, share links and design files. After a reload of a design holding `service-1` to `service-10`, the next add was `service-1` again.

Two nodes then shared one id, and everything keyed by id conflated them: selecting either selected both (the inspector read "2 components"), an edge drawn to one landed on both, and a config change applied to both. It only happens after a reload of a restored design, which is why it looks intermittent, and it gets more likely as the canvas grows.

### Fix

`makeNode` takes the set of ids already on the canvas and skips past any it would collide with, and `handleAddNode` in `App.tsx` passes that set. This is the same dedupe the paste and duplicate paths already do through `freshId` in `clipboard.ts`; the add path was the only one without it.

### Before / after

Headless, with `service-1..service-10` on the canvas and the counter at zero (a fresh page load):

    before: new id service-1   collides with existing node: true
    after:  new id service-11  collides with existing node: false

**Before:** the newly added service shares an id with an existing one, so the inspector reads "2 components" and edits apply to both.

<img width="1994" height="1464" alt="image" src="https://github.com/user-attachments/assets/abd7c48d-d0b4-4b5d-8493-e418d12f5d18" />


**After:** the new node gets its own id and is the only thing selected.

<img width="855" height="648" alt="image" src="https://github.com/user-attachments/assets/ac3f08b3-3753-4569-ae0c-2479dcb83d35" />


### Tests

`src/sim/makeNode.ids.test.ts` covers a single add against taken ids and repeated adds staying distinct. `bun run test` and `bun run build` pass locally.